### PR TITLE
Dev

### DIFF
--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -28,6 +28,8 @@ sudo $CONTROLS backup.sh rg552 &
 sleep 2
 
 SAVE_TYPES=("srm" "state*" "sav" "mcd")
+BACKUPFOLDER="roms2/backupsavs"
+TEMPFOLDER="roms2/temp_dir"
 
 BackUpSaves () {
 printf "\e[0mBacking up save files...\n"
@@ -46,11 +48,15 @@ for svfile in ${SAVE_TYPES[@]}; do #creates subdirectories for each file type.
         sudo mkdir -v /roms2/backupsavs/$svfile
     fi
 printf "\n\nFinding $svfile files and copying them to backupsavs..."
-sudo find /roms2 -name "*.$svfile" -exec cp -t /roms2/backupsavs/$svfile {} \;
+sudo find /roms2 -not -path */backupsavs/* -name "*.$svfile" -exec cp -f {} /roms2/backupsavs/$svfile \;
 done
 
 printf "\n\n\e[32mYour saves have been backed up"
 sleep 3
+}
+
+CompareSavDirs () {
+    diff -qr $BACKUPFOLDER $TEMPFOLDER 
 }
 
 dialog --title "Warning" --yesno "This will overwrite any saves in the backupsavs folder. \n Do you want to continue?\nNote:If you don't have a backupsavs folder this will create it." $height $width

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -26,7 +26,7 @@ printf "Starting Save Backup Script..." > /dev/tty1
 # Joystick controls
 # only one instance
 CONTROLS="/opt/wifi/oga_controls"
-sudo $CONTROLS Backup_Saves.sh rg552 & sleep 2
+sudo $CONTROLS Backup\ Saves.sh rg552 & sleep 2
 
 #########################
 SAVE_TYPES=("srm" "state*" "sav" "mcd")

--- a/Backup_Saves.sh
+++ b/Backup_Saves.sh
@@ -24,7 +24,7 @@ printf "Starting Save Backup Script..." > /dev/tty1
 # Joystick controls
 # only one instance
 CONTROLS="/opt/wifi/oga_controls"
-sudo $CONTROLS backup.sh rg552 &
+sudo $CONTROLS Backup_Saves.sh rg552
 sleep 2
 
 SAVE_TYPES=("srm" "state*" "sav" "mcd")

--- a/Backup_Saves.sh
+++ b/Backup_Saves.sh
@@ -50,7 +50,7 @@ sudo find /roms2 -not -path */$BACKUPFOLDER/* -name "*.$svfile" -exec cp {} /rom
 done
 
 printf "\n\n\e[32mYour saves have been backed up"
-sleep 3
+sleep 2
 }
 
 

--- a/Backup_Saves.sh
+++ b/Backup_Saves.sh
@@ -28,27 +28,24 @@ sudo $CONTROLS Backup_Saves.sh rg552
 sleep 2
 
 SAVE_TYPES=("srm" "state*" "sav" "mcd")
-BACKUPFOLDER="roms2/backupsavs"
-TEMPFOLDER="roms2/temp_dir"
+BACKUPFOLDER="backupsavs"
+TEMPFOLDER="tmp/temp_svdir"
 
 BackUpSaves () {
 printf "\e[0mBacking up save files...\n"
 
-if [ ! -d "roms2/backupsavs" ]; then
-    sudo mkdir -v /roms2/backupsavs
-fi
 
 for svfile in ${SAVE_TYPES[@]}; do #creates subdirectories for each file type. 
     if [ $svfile == 'state*' ]; then #I don't think * will play nice with folder name. 
-        if [ ! -d "/roms2/backupsavs/state" ]; then
-            sudo mkdir -v /roms2/backupsavs/state
+        if [ ! -d "/roms2/$BACKUPFOLDER/state" ]; then
+            sudo mkdir -v /roms2/$BACKUPFOLDER/state
         fi
-        sudo find /roms2 -name "*.$svfile" -exec cp -t /roms2/backupsavs/state {} \;
-    elif [ ! -d "roms2/backupsavs/$svfile" ]; then
-        sudo mkdir -v /roms2/backupsavs/$svfile
+        sudo find /roms2 -name "*.$svfile" -exec cp -t /roms2/$BACKUPFOLDER/state {} \;
+    elif [ ! -d "roms2/$BACKUPFOLDER/$svfile" ]; then
+        sudo mkdir -v /roms2/$BACKUPFOLDER/$svfile
     fi
-printf "\n\nFinding $svfile files and copying them to backupsavs..."
-sudo find /roms2 -not -path */backupsavs/* -name "*.$svfile" -exec cp -f {} /roms2/backupsavs/$svfile \;
+printf "\n\nFinding $svfile files and copying them to $BACKUPFOLDER..."
+sudo find /roms2 -not -path */$BACKUPFOLDER/* -name "*.$svfile" -exec cp -f {} /roms2/$BACKUPFOLDER/$svfile \;
 done
 
 printf "\n\n\e[32mYour saves have been backed up"
@@ -56,18 +53,34 @@ sleep 3
 }
 
 CompareSavDirs () {
-    diff -qr $BACKUPFOLDER $TEMPFOLDER 
+    diff -qr roms2/$BACKUPFOLDER $TEMPFOLDER 
 }
 
-dialog --title "Warning" --yesno "This will overwrite any saves in the backupsavs folder. \n Do you want to continue?\nNote:If you don't have a backupsavs folder this will create it." $height $width
-if [ $? = 0 ]; then
+if [ ! -d "roms2/$BACKUPFOLDER" ]; then
+    sudo mkdir -v /roms2/$BACKUPFOLDER
     BackUpSaves
-    pgrep -f oga_controls | sudo xargs kill -9
-elif [ $? = 1 ]; then
-    printf "No action taken. Exiting Script..."
-    sleep 2
-    pgrep -f oga_controls | sudo xargs kill -9
-    exit 1
-fi
+else
+    dialog --title "Warning" --yesno "This will overwrite any saves in the $BACKUPFOLDER folder. \n Do you want to continue?\nNote:If you don't have a $BACKUPFOLDER folder this will create it." $height $width
+    response=$?
+    case $response in
+        0) BackUpSaves
+        pgrep -f oga_controls | sudo xargs kill -9;;
+   1) printf "No action taken. Exiting Script..."
+     sleep 2
+     pgrep -f oga_controls | sudo xargs kill -9
+     exit 1;;
+   255) echo "[ESC] key pressed.";;
+esac
+
+
+# if [ $? = 0 ]; then
+#     BackUpSaves
+#     pgrep -f oga_controls | sudo xargs kill -9
+# elif [ $? = 1 ]; then
+#     printf "No action taken. Exiting Script..."
+#     sleep 2
+#     pgrep -f oga_controls | sudo xargs kill -9
+#     exit 1
+# fi
 
 exit 0

--- a/Backup_Saves.sh
+++ b/Backup_Saves.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-#Script to check to see if there are Save files. Then backs them up. 
+#Script to check to see if there are save files. Then backs them up. 
+#Created by TheExcitedTech
+
 #LOG_FILE='/roms2/backupsavs/backupsavs.log'
 sudo chmod 666 /dev/tty1
 printf "\033c" > /dev/tty1
@@ -24,63 +26,58 @@ printf "Starting Save Backup Script..." > /dev/tty1
 # Joystick controls
 # only one instance
 CONTROLS="/opt/wifi/oga_controls"
-sudo $CONTROLS Backup_Saves.sh rg552
-sleep 2
+sudo $CONTROLS Backup_Saves.sh rg552 & sleep 2
 
+#########################
 SAVE_TYPES=("srm" "state*" "sav" "mcd")
 BACKUPFOLDER="backupsavs"
-TEMPFOLDER="tmp/temp_svdir"
+#########################
 
 BackUpSaves () {
 printf "\e[0mBacking up save files...\n"
 
-
 for svfile in ${SAVE_TYPES[@]}; do #creates subdirectories for each file type. 
-    if [ $svfile == 'state*' ]; then #I don't think * will play nice with folder name. 
+    if [ $svfile == 'state*' ]; then
         if [ ! -d "/roms2/$BACKUPFOLDER/state" ]; then
             sudo mkdir -v /roms2/$BACKUPFOLDER/state
         fi
-        sudo find /roms2 -name "*.$svfile" -exec cp -t /roms2/$BACKUPFOLDER/state {} \;
-    elif [ ! -d "roms2/$BACKUPFOLDER/$svfile" ]; then
+        sudo find /roms2 -not -path */$BACKUPFOLDER/* -name "*.$svfile" -exec cp {} /roms2/$BACKUPFOLDER/state \;
+    elif [ ! -d "/roms2/$BACKUPFOLDER/$svfile" ]; then
         sudo mkdir -v /roms2/$BACKUPFOLDER/$svfile
     fi
 printf "\n\nFinding $svfile files and copying them to $BACKUPFOLDER..."
-sudo find /roms2 -not -path */$BACKUPFOLDER/* -name "*.$svfile" -exec cp -f {} /roms2/$BACKUPFOLDER/$svfile \;
+sudo find /roms2 -not -path */$BACKUPFOLDER/* -name "*.$svfile" -exec cp {} /roms2/$BACKUPFOLDER/$svfile \;
 done
 
 printf "\n\n\e[32mYour saves have been backed up"
 sleep 3
 }
 
-CompareSavDirs () {
-    diff -qr roms2/$BACKUPFOLDER $TEMPFOLDER 
-}
 
-if [ ! -d "roms2/$BACKUPFOLDER" ]; then
+StartBackupFunction () {
+if [ ! -d "/roms2/$BACKUPFOLDER" ]; then
     sudo mkdir -v /roms2/$BACKUPFOLDER
     BackUpSaves
+    pgrep -f oga_controls | sudo xargs kill -9
 else
-    dialog --title "Warning" --yesno "This will overwrite any saves in the $BACKUPFOLDER folder. \n Do you want to continue?\nNote:If you don't have a $BACKUPFOLDER folder this will create it." $height $width
-    response=$?
-    case $response in
-        0) BackUpSaves
-        pgrep -f oga_controls | sudo xargs kill -9;;
-   1) printf "No action taken. Exiting Script..."
-     sleep 2
-     pgrep -f oga_controls | sudo xargs kill -9
-     exit 1;;
-   255) echo "[ESC] key pressed.";;
-esac
+    BackupWarning
+fi
+}
 
+BackupWarning () {
+dialog --title "Warning" --yesno "This will overwrite any saves in the $BACKUPFOLDER folder. \n Do you want to continue?\nNote:If you don't have a $BACKUPFOLDER folder this will create it." $height $width
+if [ $? = 0 ]; then
+    BackUpSaves
+    pgrep -f oga_controls | sudo xargs kill -9
+elif [ $? = 1 ]; then
+    printf "No action taken. Exiting Script..."
+    sleep 2
+    pgrep -f oga_controls | sudo xargs kill -9
+    exit 1
+fi
+}
 
-# if [ $? = 0 ]; then
-#     BackUpSaves
-#     pgrep -f oga_controls | sudo xargs kill -9
-# elif [ $? = 1 ]; then
-#     printf "No action taken. Exiting Script..."
-#     sleep 2
-#     pgrep -f oga_controls | sudo xargs kill -9
-#     exit 1
-# fi
+StartBackupFunction
+clear
 
 exit 0

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Designed around the 353V Device with ArkOS. The filepaths are hardcoded to look 
 Make sure to set this as executable before using. 
 
 **Please make sure to offload the backupsavs folder to another location, such as a cloud storage location.**
+
+Dev Branch is to mess with the script to add experimental features.
+
+**Dev Branch can/will/probably break the script. Be careful with using the script in the dev branch. You are responsible for your own data. **


### PR DESCRIPTION
Broken the code into smaller functions. Fixed bugs
Finding the $BACKUPFOLDER was missing a '/'.
The script will now warn you if you already have a backup folder, otherwise if ran for the first time, it will kick off the backup!
Removed the CompareSavDirs function as it's not being used.
Tidied up the code for consistent formatting.
Script now will clear from terminal output after running.
This commit has been tested and verified, will merge into main branch.