### PR TITLE
Dev

### DIFF
--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -20,6 +20,7 @@ sudo $CONTROLS Backup\ Saves.sh rg552 & sleep 2 #Joystick controls
 SAVE_TYPES=("srm" "state*" "sav" "mcd" "eep" "mpk" "st0")
 BACKUP_DIR=${1:-"backupsavs"} #BACKUP FOLDER
 ROM_DIRS=()
+CHECKED_ROM_DIRS=()
 TMP_FILE="/tmp/romdirectories.txt"
 #########################
 
@@ -29,20 +30,20 @@ FindGameDir () {
 ####If there is content in ROM_DIRS, create directory in $BACKUP_DIR and look for $SAVE_TYPES in the directory to backup 
 ####This will make it easier to organize the save data by system
 #### Write the function in a way that checks for the directories in roms2. So if there is custom systems/collections this will also backup their saves. Keep this versatile and scalable. 
-
+printf "Finding ROM directories and creating system backup folders...\n"
 ls -d1 /roms2 > "$TMP_FILE" #Only shows parent rom directories.
 while read -r line; do
     ROM_DIRS+=("$line\n")
 done < $TMP_FILE 
 
 for log in ${ROM_DIRS[@]}; do
-        if [ "$(ls -A "/roms2/$log")"  ]; then
-            mkdir "/roms2/$BACKUP_DIR/$log"
-            
-        else
+    if [ -z "$(ls -A "/roms2/$log" 2>/dev/null)"  ]; then #Checks if there are any files in the directories.
         continue
-        fi
-
+    fi
+    if [ ! -d "/roms2/$BACKUP_DIR/$log" ]; then
+        sudo mkdir -v /roms2/"$BACKUP_DIR"/"$log"; printf "\n"
+    fi
+    CHECKED_ROM_DIRS+=("$log\n")
 done
     #while read temp file line by line - add each to an array(ROM_DIRS)
     #Loop through directories and check if there is content in there
@@ -50,24 +51,14 @@ done
     #rm temporary file  
 
 }
+
 BackUpSaves () {
 printf "\e[0mBacking up save files...\n"
-
-for svfile in ${SAVE_TYPES[@]}; do #creates subdirectories for each file type. 
-    if [ "$svfile" == 'state*' ]; then
-        if [ ! -d "/roms2/$BACKUP_DIR/state" ]; then
-            printf "\n"
-            sudo mkdir -v /roms2/$BACKUP_DIR/state
-        fi
-        printf "Finding $svfile files and copying them to $BACKUP_DIR/state...\n"
-        sudo find /roms2 -not -path */$BACKUP_DIR/* -name "*.$svfile" -exec cp {} /roms2/$BACKUP_DIR/state \;
-        continue
-    elif [ ! -d "/roms2/$BACKUP_DIR/$svfile" ]; then
-        printf "\n"
-        sudo mkdir -v /roms2/"$BACKUP_DIR"/"$svfile"
-    fi
-printf "Finding $svfile files and copying them to $BACKUP_DIR/$svfile...\n"
-sudo find /roms2 -not -path */$BACKUP_DIR/* -name "*.$svfile" -exec cp {} /roms2/$BACKUP_DIR/"$svfile" \;
+for dir in ${CHECKED_ROM_DIRS[@]}; do
+    for svfile in ${SAVE_TYPES[@]}; do 
+        printf "Finding $svfile files and copying them to $BACKUP_DIR/$dir/...\n"
+        sudo find /roms2/"$dir" -not -path */$BACKUP_DIR/* -name "*.$svfile" -exec cp {} /roms2/"$BACKUP_DIR"/"$dir" \;
+    done
 done
 
 printf "\n\n\e[32mYour saves have been backed up"
@@ -83,6 +74,7 @@ StartBackupFunction () {
 if [ ! -d "/roms2/$BACKUP_DIR" ]; then
     printf "\n"
     sudo mkdir -v /roms2/"$BACKUP_DIR"
+    FindGameDir
     BackUpSaves
 else
     BackupWarning
@@ -92,6 +84,7 @@ fi
 BackupWarning () {
 dialog --title "Warning" --yesno "This will overwrite any saves in the $BACKUP_DIR folder. \n Do you want to continue?\n" $height $width
 if [ $? = 0 ]; then
+    FindGameDir
     BackUpSaves
 elif [ $? = 1 ]; then
     printf "No action taken. Exiting Script..."

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -42,7 +42,7 @@ for log in ${ROM_DIRS[@]}; do
     if [ -z "/roms2/$log"  ]; then #Checks if there are any files in the directories.
         continue
     fi
-    if [ $log == "$BACKUP_DIR"]; then
+    if [ $log == "$BACKUP_DIR/"]; then
         continue
     fi
     if [ ! -d "/roms2/$BACKUP_DIR/$log" ]; then
@@ -61,7 +61,7 @@ BackUpSaves () {
 printf "\e[0mBacking up save files...\n"
 for dir in ${CHECKED_ROM_DIRS[@]}; do
     for svfile in ${SAVE_TYPES[@]}; do 
-        printf "Finding $svfile files and copying them to $BACKUP_DIR/$dir/...\n"
+        printf "Finding $svfile files and copying them to $BACKUP_DIR/$dir...\n"
         sudo find /roms2/"$dir" -not -path */$BACKUP_DIR/* -name "*.$svfile" -exec cp {} /roms2/"$BACKUP_DIR"/"$dir" \;
     done
 done

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -31,13 +31,13 @@ FindGameDir () {
 ####This will make it easier to organize the save data by system
 #### Write the function in a way that checks for the directories in roms2. So if there is custom systems/collections this will also backup their saves. Keep this versatile and scalable. 
 printf "Finding ROM directories and creating system backup folders...\n"
-ls -d1 /roms2 > "$TMP_FILE" #Only shows parent rom directories.
+ls -d1 /roms2/*/ > "$TMP_FILE" #Only shows parent rom directories.
 while read -r line; do
     ROM_DIRS+=("$line\n")
 done < $TMP_FILE 
 
 for log in ${ROM_DIRS[@]}; do
-    if [ -n "$(ls -A "/roms2/$log" 2>/dev/null)"  ]; then #Checks if there are any files in the directories.
+    if [ -z "/roms2/$log"  ]; then #Checks if there are any files in the directories.
         continue
     fi
     if [ $log == "$BACKUP_DIR"]; then

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -19,8 +19,23 @@ sudo $CONTROLS Backup\ Saves.sh rg552 & sleep 2 #Joystick controls
 #########################
 SAVE_TYPES=("srm" "state*" "sav" "mcd" "eep" "mpk" "st0")
 BACKUP_DIR=${1:-"backupsavs"} #BACKUP FOLDER
+ROM_DIRS=()
 #########################
 
+FindGameDir () {
+
+####Iterate through ROM_DIRS
+####If there is content in ROM_DIRS, create directory in $BACKUP_DIR and look for $SAVE_TYPES in the directory to backup 
+####This will make it easier to organize the save data by system
+#### Write the function in a way that checks for the directories in roms2. So if there is custom systems/collections this will also backup their saves. Keep this versatile and scalable. 
+
+    ls -1 /roms2 > #to temp file /tmp/
+    #while read temp file line by line - add each to an array(ROM_DIRS)
+    #Loop through directories and check if there is content in there
+    #If there is content, check if there is any SAVE_TYPES and create folder in BACKUPDIR with ROM_DIRS name and copy SAVE_TYPES in there
+    #rm temporary file  
+
+}
 BackUpSaves () {
 printf "\e[0mBacking up save files...\n"
 

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -20,6 +20,7 @@ sudo $CONTROLS Backup\ Saves.sh rg552 & sleep 2 #Joystick controls
 SAVE_TYPES=("srm" "state*" "sav" "mcd" "eep" "mpk" "st0")
 BACKUP_DIR=${1:-"backupsavs"} #BACKUP FOLDER
 ROM_DIRS=()
+TMP_FILE="/tmp/romdirectories.txt"
 #########################
 
 FindGameDir () {
@@ -29,7 +30,20 @@ FindGameDir () {
 ####This will make it easier to organize the save data by system
 #### Write the function in a way that checks for the directories in roms2. So if there is custom systems/collections this will also backup their saves. Keep this versatile and scalable. 
 
-    ls -1 /roms2 > #to temp file /tmp/
+ls -d1 /roms2 > "$TMP_FILE" #Only shows parent rom directories.
+while read -r line; do
+    ROM_DIRS+=("$line\n")
+done < $TMP_FILE 
+
+for log in ${ROM_DIRS[@]}; do
+        if [ "$(ls -A "/roms2/$log")"  ]; then
+            mkdir "/roms2/$BACKUP_DIR/$log"
+            
+        else
+        continue
+        fi
+
+done
     #while read temp file line by line - add each to an array(ROM_DIRS)
     #Loop through directories and check if there is content in there
     #If there is content, check if there is any SAVE_TYPES and create folder in BACKUPDIR with ROM_DIRS name and copy SAVE_TYPES in there

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -39,10 +39,10 @@ while read -r line; do
 done < $TMP_FILE 
 
 for log in ${ROM_DIRS[@]}; do
-    if [ -z "/roms2/$log"  ]; then #Checks if there are any files in the directories.
+    if [ -z "$(ls -A $ROMS2/$log)" ]; then #Skips diretory if there are no files in it.
         continue
     fi
-    if [ $log == "$BACKUP_DIR/"]; then
+    if [ $log == "$BACKUP_DIR/" ]; then
         continue
     fi
     if [ ! -d "/roms2/$BACKUP_DIR/$log" ]; then
@@ -60,9 +60,12 @@ done
 BackUpSaves () {
 printf "\e[0mBacking up save files...\n"
 for dir in ${CHECKED_ROM_DIRS[@]}; do
+    if [ $dir == "dreamcast/" ]; then
+        sudo find /roms2/"$dir" -name "*.bin" -exec cp {} /roms2/"$BACKUP_DIR"/"$dir" \;
+    fi
     for svfile in ${SAVE_TYPES[@]}; do 
         printf "Finding $svfile files and copying them to $BACKUP_DIR/$dir...\n"
-        sudo find /roms2/"$dir" -not -path */$BACKUP_DIR/* -name "*.$svfile" -exec cp {} /roms2/"$BACKUP_DIR"/"$dir" \;
+        sudo find /roms2/"$dir" -name "*.$svfile" -exec cp {} /roms2/"$BACKUP_DIR"/"$dir" \;
     done
 done
 

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -40,6 +40,9 @@ for log in ${ROM_DIRS[@]}; do
     if [ -z "$(ls -A "/roms2/$log" 2>/dev/null)"  ]; then #Checks if there are any files in the directories.
         continue
     fi
+    if [ $log == "$BACKUP_DIR"]; then
+        continue
+    fi
     if [ ! -d "/roms2/$BACKUP_DIR/$log" ]; then
         sudo mkdir -v /roms2/"$BACKUP_DIR"/"$log"; printf "\n"
     fi

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -37,7 +37,7 @@ while read -r line; do
 done < $TMP_FILE 
 
 for log in ${ROM_DIRS[@]}; do
-    if [ -z "$(ls -A "/roms2/$log" 2>/dev/null)"  ]; then #Checks if there are any files in the directories.
+    if [ -n "$(ls -A "/roms2/$log" 2>/dev/null)"  ]; then #Checks if there are any files in the directories.
         continue
     fi
     if [ $log == "$BACKUP_DIR"]; then
@@ -96,7 +96,10 @@ elif [ $? = 1 ]; then
     exit 1
 fi
 }
-
+main () {
 StartBackupFunction
 KillControls
+}
+
+main
 exit 0

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 #Script to check to see if there are save files. Then backs them up. 
 #Created by TheExcitedTech
 
@@ -26,20 +25,16 @@ ROMS2="/roms2/"
 #########################
 
 FindGameDir () {
-
-####Iterate through ROM_DIRS
-####If there is content in ROM_DIRS, create directory in $BACKUP_DIR and look for $SAVE_TYPES in the directory to backup 
-####This will make it easier to organize the save data by system
-#### Write the function in a way that checks for the directories in roms2. So if there is custom systems/collections this will also backup their saves. Keep this versatile and scalable. 
+ 
 printf "Finding ROM directories and creating system backup folders...\n"
 ls -d1 /roms2/*/ > "$TMP_FILE" #Only shows parent rom directories.
 while read -r line; do
-    line=$(cut -c 8- <<< "$line") #Removes the '/roms2/' from the array. 
+    line=$(cut -c 8- <<< "$line") #Removes the '/roms2/' from the array items.
     ROM_DIRS+=("$line")
 done < $TMP_FILE 
 
 for log in ${ROM_DIRS[@]}; do
-    if [ -z "$(ls -A $ROMS2/$log)" ]; then #Skips diretory if there are no files in it.
+    if [ -z "$(ls -A $ROMS2/$log)" ]; then #Skips directory if it's empty.
         continue
     fi
     if [ $log == "$BACKUP_DIR/" ]; then
@@ -48,13 +43,8 @@ for log in ${ROM_DIRS[@]}; do
     if [ ! -d "/roms2/$BACKUP_DIR/$log" ]; then
         sudo mkdir -v /roms2/"$BACKUP_DIR"/"$log"; printf "\n"
     fi
-    CHECKED_ROM_DIRS+=("$log")
+    CHECKED_ROM_DIRS+=("$log") #This array only stores the names of the directories that aren't empty. 
 done
-    #while read temp file line by line - add each to an array(ROM_DIRS)
-    #Loop through directories and check if there is content in there
-    #If there is content, check if there is any SAVE_TYPES and create folder in BACKUPDIR with ROM_DIRS name and copy SAVE_TYPES in there
-    #rm temporary file  
-
 }
 
 BackUpSaves () {
@@ -101,6 +91,7 @@ elif [ $? = 1 ]; then
     exit 1
 fi
 }
+
 main () {
 StartBackupFunction
 KillControls

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -22,6 +22,7 @@ BACKUP_DIR=${1:-"backupsavs"} #BACKUP FOLDER
 ROM_DIRS=()
 CHECKED_ROM_DIRS=()
 TMP_FILE="/tmp/romdirectories.txt"
+ROMS2="/roms2/"
 #########################
 
 FindGameDir () {
@@ -33,7 +34,8 @@ FindGameDir () {
 printf "Finding ROM directories and creating system backup folders...\n"
 ls -d1 /roms2/*/ > "$TMP_FILE" #Only shows parent rom directories.
 while read -r line; do
-    ROM_DIRS+=("$line\n")
+    line=$(cut -c 8- <<< "$line") #Removes the '/roms2/' from the array. 
+    ROM_DIRS+=("$line")
 done < $TMP_FILE 
 
 for log in ${ROM_DIRS[@]}; do
@@ -46,7 +48,7 @@ for log in ${ROM_DIRS[@]}; do
     if [ ! -d "/roms2/$BACKUP_DIR/$log" ]; then
         sudo mkdir -v /roms2/"$BACKUP_DIR"/"$log"; printf "\n"
     fi
-    CHECKED_ROM_DIRS+=("$log\n")
+    CHECKED_ROM_DIRS+=("$log")
 done
     #while read temp file line by line - add each to an array(ROM_DIRS)
     #Loop through directories and check if there is content in there
@@ -102,4 +104,5 @@ KillControls
 }
 
 main
+
 exit 0

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ You can also change the default directory by editing the `BACKUP_DIR` variable.
 Dev Branch is to mess with the script to add experimental features. Will merge into main branch when changes have been tested and functionally verified. We should never code directly in PROD
 
 *Dev Branch can/will probably break the script. Be careful with using the script in the dev branch.*
+
+Dev Branch has support for organizing the backups by system folder in the $BACKUP_DIR. 


### PR DESCRIPTION
The script can now organize the saves by the system. It will check to see if there is content in the parent ROMs directory. If there is at least 1 file, it will create a folder in the $BACKUP_DIR with the folder title and scan the directory to see if there are any save files to backup.  

The goal is to make it easier to restore the save files in their respective directories.

Tested and verified by running via SSH, as well as running the script directly through a 353V. 

This is a big update, and I am happy with it. Before, the script would find some save-type files. Now it'll be easier to build in some specific logic for systems. An example is the Dreamcast save files are .bin files. The script knows to look for .bin files in the Dreamcast folder.  If the script checked for .bin files in all directories, it could potentially copy ROMs to the backup folder, and we don't want that. 

There isn't any logic for cases like the dreamcast if the default save data path is changed in an emulator. These are edge cases, as mentioned above ^. 

Here is the commit to the version of the script that checked for some save files and copied them into a backupsavs directory you can access that version with this commit. d080966